### PR TITLE
Fix for #24

### DIFF
--- a/PowerShell/BloodHound.ps1
+++ b/PowerShell/BloodHound.ps1
@@ -5421,6 +5421,8 @@ function Get-NetGroupMember {
                 }
 
                 $Members = @()
+                $GroupSearcher.PropertiesToLoad.Clear()
+                $Result = $False
                 try {
                     $Result = $GroupSearcher.FindOne()
                 }


### PR DESCRIPTION
fix for my issue #24.

after we have set `$GroupSearcher.PropertiesToLoad`  once, subsequent calls to FindOne() will fail when trying to find the next group. If we still have a `$Result`, and that `$Result` contains a property named `member`, the loop will continue using the previous successful search results as though they are the current search results, resulting in reprocessing the previous group. This appears to the user as a recursive loop.
